### PR TITLE
Windows js fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val workspaceDirectory: File =
     case _ => Path.userHome / "mulesoft"
   }
 
-val syamlVersion = "0.7.239"
+val syamlVersion = "0.7.240"
 
 lazy val syamlJVMRef = ProjectRef(workspaceDirectory / "syaml", "syamlJVM")
 lazy val syamlJSRef = ProjectRef(workspaceDirectory / "syaml", "syamlJS")

--- a/js/src/main/scala/amf/core/remote/server/JsServerPlatform.scala
+++ b/js/src/main/scala/amf/core/remote/server/JsServerPlatform.scala
@@ -32,12 +32,8 @@ class JsServerPlatform extends JsPlatform {
 
   override def resolvePath(uri: String): String = {
     uri match {
-      case File(path) =>
-        operativeSystem() match {
-          case "win" => (FILE_PROTOCOL + normalizeURL(path)).replace("\\", "/") // TODO: with scala-common update replace for separator
-          case _ => FILE_PROTOCOL + normalizeURL(path)
-        }
-
+      case File(path) if fs.separatorChar == "/" => FILE_PROTOCOL + normalizeURL(path)
+      case File(path) => FILE_PROTOCOL + normalizeURL(path).replace(fs.separatorChar.toString, "/")
       case HttpParts(protocol, host, path) => protocol + host + normalizePath(withTrailingSlash(path))
       case _                               => uri
     }

--- a/js/src/main/scala/amf/core/remote/server/JsServerPlatform.scala
+++ b/js/src/main/scala/amf/core/remote/server/JsServerPlatform.scala
@@ -34,12 +34,8 @@ class JsServerPlatform extends JsPlatform {
     uri match {
       case File(path) =>
         operativeSystem() match {
-          case "win" =>
-            if (path.startsWith("/")) FILE_PROTOCOL + normalizeURL(path).substring(1)
-            else FILE_PROTOCOL + normalizeURL(withTrailingSlash(path)).substring(1)
-          case _ =>
-            if (path.startsWith("/")) FILE_PROTOCOL + normalizeURL(path)
-            else FILE_PROTOCOL + normalizeURL(withTrailingSlash(path)).substring(1)
+          case "win" => (FILE_PROTOCOL + normalizeURL(path)).replace("\\", "/") // TODO: with scala-common update replace for separator
+          case _ => FILE_PROTOCOL + normalizeURL(path)
         }
 
       case HttpParts(protocol, host, path) => protocol + host + normalizePath(withTrailingSlash(path))

--- a/shared/src/test/scala/amf/core/common/DiffTest.scala
+++ b/shared/src/test/scala/amf/core/common/DiffTest.scala
@@ -25,7 +25,7 @@ class DiffTest extends FunSuite with ListAssertions {
       ">     The door of all subtleties!\n"
 
     assertResult(out2) {
-      Diff.makeString(deltas)
+      Diff.makeString(deltas).replace("\r\n", "\n")
     }
 
     deltas.head.toString should startWith("Diff.Delta(0, c, 0, (  The")
@@ -51,7 +51,7 @@ class DiffTest extends FunSuite with ListAssertions {
       ">     They both may be called deep and profound.\n" +
       ">     Deeper and more profound\n" +
       ">     The door of all subtleties!\n"
-    Diff.makeString(deltas) shouldEqual out1
+    Diff.makeString(deltas).replace("\r\n", "\n") shouldEqual out1
   }
 
   test("Diff Strings By Line") {

--- a/shared/src/test/scala/amf/core/io/FileAssertionTest.scala
+++ b/shared/src/test/scala/amf/core/io/FileAssertionTest.scala
@@ -24,8 +24,12 @@ trait FileAssertionTest extends PlatformSecrets {
     expected.read().flatMap(_ => checkDiff(actual, expected))
   }
 
+  private def withTrailingSeparator(dir: String, char: Char): String = {
+    if(dir.endsWith(char.toString)) dir
+    else dir.concat(char.toString)
+  }
+
   /** Return random temporary file name for testing. */
   def tmp(name: String = ""): String =
-    (platform.tmpdir() + platform.fs.separatorChar + System.nanoTime() + "-" + name)
-      .replaceAll(s"${platform.fs.separatorChar}${platform.fs.separatorChar}", s"${platform.fs.separatorChar}")
+    withTrailingSeparator(platform.tmpdir(), platform.fs.separatorChar) + System.nanoTime() + "-" + name
 }

--- a/shared/src/test/scala/amf/core/io/FileAssertionTest.scala
+++ b/shared/src/test/scala/amf/core/io/FileAssertionTest.scala
@@ -9,27 +9,30 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait FileAssertionTest extends PlatformSecrets {
 
-  private implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+  private implicit val executionContext: ExecutionContext =
+    ExecutionContext.Implicits.global
 
   protected val fs: FileSystem = platform.fs
 
-  protected def writeTemporaryFile(golden: String)(content: String): Future[AsyncFile] = {
-    val file   = tmp(s"${golden.replaceAll("/", "-")}.tmp")
+  protected def writeTemporaryFile(golden: String)(
+      content: String): Future[AsyncFile] = {
+    val file = tmp(s"${golden.replaceAll("/", "-")}.tmp")
     val actual = fs.asyncFile(file)
     actual.write(content).map(_ => actual)
   }
 
-  protected def assertDifferences(actual: AsyncFile, golden: String): Future[Assertion] = {
+  protected def assertDifferences(actual: AsyncFile,
+                                  golden: String): Future[Assertion] = {
     val expected = fs.asyncFile(golden)
     expected.read().flatMap(_ => checkDiff(actual, expected))
   }
 
-  private def withTrailingSeparator(dir: String, char: Char): String = {
-    if(dir.endsWith(char.toString)) dir
+  private def withTrailingSeparator(dir: String, char: Char): String =
+    if (dir.endsWith(char.toString)) dir
     else dir.concat(char.toString)
-  }
 
   /** Return random temporary file name for testing. */
   def tmp(name: String = ""): String =
-    withTrailingSeparator(platform.tmpdir(), platform.fs.separatorChar) + System.nanoTime() + "-" + name
+    withTrailingSeparator(platform.tmpdir(), platform.fs.separatorChar) + System
+      .nanoTime() + "-" + name
 }

--- a/shared/src/test/scala/amf/core/remote/PlatformTest.scala
+++ b/shared/src/test/scala/amf/core/remote/PlatformTest.scala
@@ -28,7 +28,8 @@ class PlatformTest extends AsyncFunSuite with ListAssertions with PlatformSecret
                      |  - 2
                      |d: !include includes/include2.yaml""".stripMargin
 
-        content.sourceName should be("shared/src/test/resources/input.yaml")
+        // TODO: replace for fs.separatorChar when fixed for JS
+        content.sourceName.replace("\\","/") should be("shared/src/test/resources/input.yaml")
     }
   }
 

--- a/shared/src/test/scala/amf/core/remote/PlatformTest.scala
+++ b/shared/src/test/scala/amf/core/remote/PlatformTest.scala
@@ -28,8 +28,7 @@ class PlatformTest extends AsyncFunSuite with ListAssertions with PlatformSecret
                      |  - 2
                      |d: !include includes/include2.yaml""".stripMargin
 
-        // TODO: replace for fs.separatorChar when fixed for JS
-        content.sourceName.replace("\\","/") should be("shared/src/test/resources/input.yaml")
+        content.sourceName.replace(platform.fs.separatorChar.toString,"/") should be("shared/src/test/resources/input.yaml")
     }
   }
 


### PR DESCRIPTION
Tests passing on Windows.
Changes in JsPlatform (for Windows only) and some Tests (all of which should only be noticeable on Windows)
For this to run smoothly in Windows, it's necessary to apply changes on scala-common FileSystem (in JS, the "separatorChar", branch windows-paths)